### PR TITLE
Update license attribute

### DIFF
--- a/package.json.ls
+++ b/package.json.ls
@@ -13,10 +13,7 @@ files:
 main: './lib/'
 
 bugs: 'https://github.com/gkz/optionator/issues'
-licenses:
-  * type: 'MIT'
-    url: 'https://raw.githubusercontent.com/gkz/optionator/master/LICENSE'
-  ...
+license: 'MIT'
 engines:
   node: '>= 0.8.0'
 repository:


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/