### PR TITLE
Upgrading fast-levenshtein version to avoid deprecated lodash version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "wordwrap": "~1.0.0",
     "type-check": "~0.3.2",
     "levn": "~0.3.0",
-    "fast-levenshtein": "~1.0.7"
+    "fast-levenshtein": "^1.1.0"
   },
   "devDependencies": {
     "livescript": "~1.4.0",


### PR DESCRIPTION
I bumped the version of your fast-levenshtein dep to avoid pulling in a deprecated version of lodash. 

All tests pass. Please accept and publish to NPM. Thanks!