### PR TITLE
:tophat: dependencies and migrate mocha

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ all: build
 build: $(LIB) package.json
 
 test: build
-	$(MOCHA) --reporter dot --ui tdd --compilers ls:$(LS)
+	$(MOCHA) --reporter dot --ui tdd --require $(LS) "test/*.ls"
 
 coverage: build
-	$(ISTANBUL) cover $(MOCHA2) -- --reporter dot --ui tdd --compilers ls:$(LS)
+	$(ISTANBUL) cover $(MOCHA2) -- --reporter dot --ui tdd --require $(LS) "test/*.ls"
 
 dev-install: package.json
 	npm install .

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
     "wordwrap": "~1.0.0",
     "type-check": "~0.3.2",
     "levn": "~0.3.0",
-    "fast-levenshtein": "~2.0.4"
+    "fast-levenshtein": "~2.0.6"
   },
   "devDependencies": {
-    "livescript": "~1.5.0",
-    "mocha": "~3.0.2",
-    "istanbul": "~0.4.1"
+    "livescript": "~1.6.0",
+    "mocha": "~5.2.0",
+    "istanbul": "~0.4.5"
   }
 }

--- a/package.json.ls
+++ b/package.json.ls
@@ -31,9 +31,9 @@ dependencies:
   wordwrap: '~1.0.0'
   'type-check': '~0.3.2'
   levn: '~0.3.0'
-  'fast-levenshtein': '~2.0.4'
+  'fast-levenshtein': '~2.0.6'
 
 dev-dependencies:
-  livescript: '~1.5.0'
-  mocha: '~3.0.2'
-  istanbul: '~0.4.1'
+  livescript: '~1.6.0'
+  mocha: '~5.2.0'
+  istanbul: '~0.4.5'


### PR DESCRIPTION
Updates whatever dependencies could, there was not much change.

Mocha had few major releases since the last update and hence migrated the command line options for it.

While installing initially with `npm install`, there were 2 audit issues.
Once this PR is merged, there are 0 audit issues 🎅 