### PR TITLE
Use fastest-levenshtein instead of fast-levenshtein

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -2,7 +2,7 @@
 (function(){
   var prelude, map, sortBy, fl, closestString, nameToRaw, dasherize, naturalJoin;
   prelude = require('prelude-ls'), map = prelude.map, sortBy = prelude.sortBy;
-  fl = require('fast-levenshtein');
+  fl = require('fastest-levenshtein');
   closestString = function(possibilities, input){
     var distances, ref$, string, distance;
     if (!possibilities.length) {
@@ -15,7 +15,7 @@
         : [it, input], longer = ref$[0], shorter = ref$[1];
       return {
         string: it,
-        distance: fl.get(longer, shorter)
+        distance: fl.distance(longer, shorter)
       };
     })(
     possibilities);

--- a/package-lock.json
+++ b/package-lock.json
@@ -277,7 +277,13 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fastest-levenshtein": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.10.tgz",
+      "integrity": "sha512-47cjEZM1VsM21NQtVunzK/c4ZezeS0FIYRNZ/ovHY234NQ2BNvLMmAIjYfb+lVZAKI1h3GZwYAl1Pu6isaIJIQ=="
     },
     "fill-range": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "word-wrap": "^1.2.3",
     "type-check": "^0.4.0",
     "levn": "^0.4.1",
-    "fast-levenshtein": "^2.0.6"
+    "fastest-levenshtein": "^1.0.10"
   },
   "devDependencies": {
     "livescript": "^1.6.0",

--- a/package.json.ls
+++ b/package.json.ls
@@ -31,7 +31,7 @@ dependencies:
   'word-wrap': '^1.2.3'
   'type-check': '^0.4.0'
   levn: '^0.4.1'
-  'fast-levenshtein': '^2.0.6'
+  'fastest-levenshtein': '^1.0.10'
 
 dev-dependencies:
   livescript: '^1.6.0'

--- a/src/util.ls
+++ b/src/util.ls
@@ -1,11 +1,11 @@
 {map, sort-by}:prelude = require 'prelude-ls'
-fl = require 'fast-levenshtein'
+fl = require 'fastest-levenshtein'
 
 closest-string = (possibilities, input) ->
   return unless possibilities.length
   distances = possibilities |> map ->
     [longer, shorter] = if input.length > it.length then [input, it] else [it, input]
-    {string: it, distance: fl.get longer, shorter}
+    {string: it, distance: fl.distance longer, shorter}
 
   {string, distance} = sort-by (.distance), distances .0
   string


### PR DESCRIPTION
`fast-levenshtein` uses `fastest-levenshtein` under the hood in the newest version (v3.0.0) offering much better performance (15x faster in some cases). Since `fast-levenshtein` is just a wrapper of `fastest-levenshtein`, this package should just use [`fastest-levenshtein`](https://github.com/ka-weihe/fastest-levenshtein) directly instead. 