### PR TITLE
Fix broken repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/gkz/optionator.git"
+    "url": "https://github.com/gkz/optionator.git"
   },
   "scripts": {
     "test": "make test"

--- a/package.json.ls
+++ b/package.json.ls
@@ -21,7 +21,7 @@ engines:
   node: '>= 0.8.0'
 repository:
   type: 'git'
-  url: 'git://github.com/gkz/optionator.git'
+  url: 'https://github.com/gkz/optionator.git'
 scripts:
   test: "make test"
 


### PR DESCRIPTION
GitHub hasn't supported the git protocol [since 2022](https://github.blog/security/application-security/improving-git-protocol-security-github/#no-more-unauthenticated-git), so this URL is broken.

(This is a common error affecting many popular npm packages; I'm opening PRs on several projects to fix it. I encourage anyone reading this to check any packages they maintain and implement the same fix if appropriate!)